### PR TITLE
Only trigger CD workflow on production paths

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -3,6 +3,10 @@ name: Continuous Deployment
 
 on:
   push:
+    paths:
+    - 'src/**'
+    - 'composer.*'
+    - 'server.php'
     branches:
     - master
 


### PR DESCRIPTION
Make sure to only trigger the CD workflow if any actual files that end up in the production container (or are needed by the build container) have changed.

Changes like the one introduced in this PR (workflow file change) should not push a new image.