### PR TITLE
Trigger CD workflow on merged PR

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,7 +2,8 @@
 name: Continuous Deployment
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     paths:
     - 'src/**'
     - 'composer.*'
@@ -11,8 +12,9 @@ on:
     - master
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Now that the master branch is a protected branch and all code submissions should go through PR's, change the way the CD workflow is triggered.