### PR TITLE
Add namespace information to workload context

### DIFF
--- a/samples/commit.json
+++ b/samples/commit.json
@@ -69,7 +69,7 @@
             {
               "Container": "db",
               "Current": "postgres:11.5",
-              "Target": "postgres:12"
+              "Target": "postgres:12.0"
             }
           ]
         }

--- a/src/FluxEvent/RequestHandler.php
+++ b/src/FluxEvent/RequestHandler.php
@@ -49,7 +49,12 @@ class RequestHandler
                         $newImage = $this->shortImage($newImage);
                     }
 
-                    $response .= sprintf('* %s updated to %s', $oldImage, $newImage) . PHP_EOL;
+                    $response .= sprintf(
+                        '* [%s] %s updated to %s',
+                        $processedPayload['namespaces'][$oldImage],
+                        $oldImage,
+                        $newImage
+                    ) . PHP_EOL;
                 }
 
                 $notification = new Notification();

--- a/tests/FluxEvent/PayloadProcessorTest.php
+++ b/tests/FluxEvent/PayloadProcessorTest.php
@@ -17,7 +17,8 @@ class PayloadProcessorTest extends TestCase
             [
                 'title' => 'Applied flux changes to cluster',
                 'titleLink' => 'https://github.com/octocat/Hello-World/commit/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d',
-                'changes' => ['ubuntu:19.04' => 'ubuntu:19.10', 'postgres:11.5' => 'postgres:12.0']
+                'changes' => ['ubuntu:19.04' => 'ubuntu:19.10', 'postgres:11.5' => 'postgres:12.0'],
+                'namespaces' => ['ubuntu:19.04' => 'namespace', 'postgres:11.5' => 'namespace']
             ],
             $result
         );


### PR DESCRIPTION
Add namespace information to the response from the PayloadProcessor, so it's more obvious on what part of the cluster the changes are applied.