### PR TITLE
Fix namespace when short images are used

### DIFF
--- a/samples/commit.json
+++ b/samples/commit.json
@@ -27,17 +27,17 @@
               "ServiceID": "",
               "Container": {
                 "Name": "app",
-                "Image": "ubuntu:19.04"
+                "Image": "docker.io/ubuntu:19.04"
               },
-              "ImageID": "ubuntu:19.10"
+              "ImageID": "docker.io/ubuntu:19.10"
             },
             {
               "ServiceID": "",
               "Container": {
                 "Name": "db",
-                "Image": "postgres:11.5"
+                "Image": "docker.io/postgres:11.5"
               },
-              "ImageID": "postgres:12.0"
+              "ImageID": "docker.io/postgres:12.0"
             }
           ]
         }
@@ -58,8 +58,8 @@
           "PerContainer": [
             {
               "Container": "application",
-              "Current": "ubuntu:19.04",
-              "Target": "ubuntu:19.10"
+              "Current": "docker.io/ubuntu:19.04",
+              "Target": "docker.io/ubuntu:19.10"
             }
           ]
         },
@@ -68,8 +68,8 @@
           "PerContainer": [
             {
               "Container": "db",
-              "Current": "postgres:11.5",
-              "Target": "postgres:12.0"
+              "Current": "docker.io/postgres:11.5",
+              "Target": "docker.io/postgres:12.0"
             }
           ]
         }

--- a/src/FluxEvent/RequestHandler.php
+++ b/src/FluxEvent/RequestHandler.php
@@ -45,13 +45,14 @@ class RequestHandler
                 $response = '';
                 foreach ($processedPayload['changes'] as $oldImage => $newImage) {
                     if ($this->shortImageNames) {
+                        $fullImage = $oldImage;
                         $oldImage = $this->shortImage($oldImage);
                         $newImage = $this->shortImage($newImage);
                     }
 
                     $response .= sprintf(
                         '* [%s] %s updated to %s',
-                        $processedPayload['namespaces'][$oldImage],
+                        $processedPayload['namespaces'][$fullImage ?? $oldImage],
                         $oldImage,
                         $newImage
                     ) . PHP_EOL;

--- a/tests/FluxEvent/PayloadProcessorTest.php
+++ b/tests/FluxEvent/PayloadProcessorTest.php
@@ -17,8 +17,14 @@ class PayloadProcessorTest extends TestCase
             [
                 'title' => 'Applied flux changes to cluster',
                 'titleLink' => 'https://github.com/octocat/Hello-World/commit/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d',
-                'changes' => ['ubuntu:19.04' => 'ubuntu:19.10', 'postgres:11.5' => 'postgres:12.0'],
-                'namespaces' => ['ubuntu:19.04' => 'namespace', 'postgres:11.5' => 'namespace']
+                'changes' => [
+                    'docker.io/ubuntu:19.04' => 'docker.io/ubuntu:19.10',
+                    'docker.io/postgres:11.5' => 'docker.io/postgres:12.0'
+                ],
+                'namespaces' => [
+                    'docker.io/ubuntu:19.04' => 'namespace',
+                    'docker.io/postgres:11.5' => 'namespace'
+                ]
             ],
             $result
         );


### PR DESCRIPTION
When short image names are enabled, the namespace cannot be found, since the key of the namespaces array always uses the raw/full image name. Fix this to work in both scenarios.