### PR TITLE
Introduce ProcessedPayload object

### DIFF
--- a/src/FluxEvent/PayloadProcessor.php
+++ b/src/FluxEvent/PayloadProcessor.php
@@ -8,15 +8,15 @@ class PayloadProcessor
     /**
      * @throws \RuntimeException
      */
-    public function process(string $json): array
+    public function process(string $json): ProcessedPayload
     {
         $payload = json_decode($json);
-        $response = [
-            'title' => $payload->Title,
-            'titleLink' => $payload->TitleLink,
-            'changes' => [],
-            'namespaces' => [],
-        ];
+
+        $processedPayload = new ProcessedPayload();
+        $processedPayload->title = $payload->Title;
+        $processedPayload->titleLink = $payload->TitleLink;
+        $processedPayload->changes = [];
+        $processedPayload->namespaces = [];
 
         switch ($payload->Type) {
             case 'commit':
@@ -24,13 +24,13 @@ class PayloadProcessor
                     $oldImage = $workload->Container->Image;
                     $newImage = $workload->ImageID;
 
-                    if (!array_key_exists($oldImage, $response['changes'])) {
-                        $response['changes'][$oldImage] = $newImage;
+                    if (!array_key_exists($oldImage, $processedPayload->changes)) {
+                        $processedPayload->changes[$oldImage] = $newImage;
                     }
 
-                    if (!array_key_exists($oldImage, $response['namespaces'])) {
+                    if (!array_key_exists($oldImage, $processedPayload->namespaces)) {
                         $namespace = $this->findNamespace($payload, $oldImage);
-                        $response['namespaces'][$oldImage] = $namespace;
+                        $processedPayload->namespaces[$oldImage] = $namespace;
                     }
                 }
 
@@ -43,7 +43,7 @@ class PayloadProcessor
                 ));
         }
 
-        return $response;
+        return $processedPayload;
     }
 
     private function findNamespace(object $payload, string $image): string

--- a/src/FluxEvent/ProcessedPayload.php
+++ b/src/FluxEvent/ProcessedPayload.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace TreeHouse\FluxEvent;
+
+class ProcessedPayload
+{
+    /** @var string */
+    public $title;
+
+    /** @var string */
+    public $titleLink;
+
+    /** @var array */
+    public $changes;
+
+    /** @var array */
+    public $namespaces;
+}

--- a/src/Notifier/Notification.php
+++ b/src/Notifier/Notification.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace TreeHouse\Notifier;
 
+use TreeHouse\FluxEvent\ProcessedPayload;
+
 class Notification
 {
     /** @var string */
@@ -19,5 +21,10 @@ class Notification
         $this->title = $title;
         $this->titleLink = $titleLink;
         $this->body = $body;
+    }
+
+    public static function fromProcessedPayload(ProcessedPayload $processedPayload, string $body = null): self
+    {
+        return new static($processedPayload->title, $processedPayload->titleLink, $body);
     }
 }

--- a/tests/FluxEvent/PayloadProcessorTest.php
+++ b/tests/FluxEvent/PayloadProcessorTest.php
@@ -5,6 +5,7 @@ namespace Tests\FluxEvent;
 
 use PHPUnit\Framework\TestCase;
 use TreeHouse\FluxEvent\PayloadProcessor;
+use TreeHouse\FluxEvent\ProcessedPayload;
 
 class PayloadProcessorTest extends TestCase
 {
@@ -13,20 +14,26 @@ class PayloadProcessorTest extends TestCase
         $processor = new PayloadProcessor();
         $result = $processor->process(file_get_contents(__DIR__ . '/../../samples/commit.json'));
 
-        $this->assertSame(
-            [
-                'title' => 'Applied flux changes to cluster',
-                'titleLink' => 'https://github.com/octocat/Hello-World/commit/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d',
-                'changes' => [
-                    'docker.io/ubuntu:19.04' => 'docker.io/ubuntu:19.10',
-                    'docker.io/postgres:11.5' => 'docker.io/postgres:12.0'
-                ],
-                'namespaces' => [
-                    'docker.io/ubuntu:19.04' => 'namespace',
-                    'docker.io/postgres:11.5' => 'namespace'
-                ]
-            ],
-            $result
-        );
+        $expected = new ProcessedPayload();
+        $expected->title = 'Applied flux changes to cluster';
+        $expected->titleLink = 'https://github.com/octocat/Hello-World/commit/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d';
+        $expected->changes = [
+            'docker.io/ubuntu:19.04' => 'docker.io/ubuntu:19.10',
+            'docker.io/postgres:11.5' => 'docker.io/postgres:12.0'
+        ];
+        $expected->namespaces = [
+            'docker.io/ubuntu:19.04' => 'namespace',
+            'docker.io/postgres:11.5' => 'namespace'
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testUnknownTypeException()
+    {
+        $processor = new PayloadProcessor();
+        $json = file_get_contents(__DIR__ . '/../../samples/commit.json');
+        $this->expectException(\RuntimeException::class);
+        $processor->process(str_replace('"Type": "commit"', '"Type": "foo"', $json));
     }
 }


### PR DESCRIPTION
Introduce a ProcessedPayload object. This will pave the way to support multi-channel notifications (e.g. send notifications for different namespaces to different channels).