### PR TITLE
Add support for namespace mapping / notification channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,13 @@ docker push your-org/flux-event-handler
 The application can be configured by defining environment variables.
 The following environment variables can be set:
 
-| Name              | Description                        | Required?                | Default |
-|-------------------|------------------------------------|--------------------------|---------|
-| DEBUG             | Control verbosity                  | No                       | False   |
-| SLACK_WEBHOOK_URL | URL to your Slack incoming webhook | If SlackNotifier is used | -       |
-| SHORT_IMAGE_NAMES | Use short image names in output    | No                       | True    |
-| SLACK_USERNAME    | Username to post to Slack with     | No                       | Flux    |
-| SLACK_ICON        | User icon to post to Slack with    | No                       | :cloud: |
+| Name              | Description                         | Required?                | Default |
+|-------------------|-------------------------------------|--------------------------|---------|
+| DEBUG             | Control verbosity                   | No                       | False   |
+| SLACK_WEBHOOK_URL | URL to your Slack incoming webhook  | If SlackNotifier is used | -       |
+| SHORT_IMAGE_NAMES | Use short image names in output     | No                       | True    |
+| SLACK_USERNAME    | Username to post to Slack with      | No                       | Flux    |
+| SLACK_ICON        | User icon to post to Slack with     | No                       | :cloud: |
+| NAMESPACE_MAPPING | Namespace notification [mapping][1] | No                       | -       |
+
+[1]: src/Notifier/NamespaceMapper.php

--- a/src/Notifier/NamespaceMapper.php
+++ b/src/Notifier/NamespaceMapper.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace TreeHouse\Notifier;
+
+/**
+ * Class NamespaceMapper
+ * @package TreeHouse\Notifier
+ *
+ * Allows you to map certain namespaces to specific Notification channels.
+ * The syntax of the map should be similar to fluxcloud's map. For example for the SlackNotifier:
+ *
+ * #project=foo,#operations=*
+ *
+ * Would send all notifications regarding the "foo" namespace to the #project channel.
+ * The #operations channel would receive all notifications for any namespace.
+ */
+class NamespaceMapper
+{
+    /** @var array */
+    public $namespaceMap;
+
+    /**
+     * @throws \RuntimeException
+     */
+    public function __construct(string $mapping)
+    {
+        $namespaceMap = [];
+
+        $mappings = explode(',', $mapping);
+        foreach ($mappings as $map) {
+            if (false === strpos($map, '=')) {
+                throw new \RuntimeException(sprintf('Namespace mapping %s is invalid', $map));
+            }
+
+            list($channel, $namespace) = explode('=', $map);
+            $namespaceMap[$channel] = $namespace;
+        }
+
+        $this->namespaceMap = $namespaceMap;
+    }
+}

--- a/src/Notifier/Notification.php
+++ b/src/Notifier/Notification.php
@@ -8,23 +8,34 @@ use TreeHouse\FluxEvent\ProcessedPayload;
 class Notification
 {
     /** @var string */
+    public $body;
+
+    /** @var string */
+    public $channel;
+
+    /** @var string */
     public $title;
 
     /** @var string */
     public $titleLink;
 
-    /** @var string */
-    public $body;
-
-    public function __construct(string $title = null, string $titleLink = null, string $body = null)
-    {
+    public function __construct(
+        string $title = null,
+        string $titleLink = null,
+        string $body = null,
+        string $channel = null
+    ) {
         $this->title = $title;
         $this->titleLink = $titleLink;
         $this->body = $body;
+        $this->channel = $channel;
     }
 
-    public static function fromProcessedPayload(ProcessedPayload $processedPayload, string $body = null): self
-    {
-        return new static($processedPayload->title, $processedPayload->titleLink, $body);
+    public static function fromProcessedPayload(
+        ProcessedPayload $processedPayload,
+        string $body = null,
+        string $channel = null
+    ): self {
+        return new static($processedPayload->title, $processedPayload->titleLink, $body, $channel);
     }
 }

--- a/src/Notifier/SlackNotifier.php
+++ b/src/Notifier/SlackNotifier.php
@@ -24,10 +24,12 @@ class SlackNotifier implements Notifier
                 "attachments": [{"fallback": "%s", "title": "%s", "title_link": "%s", "text": "%s"}],
                 "username": "%s",
                 "icon_emoji": "%s"
+                %s
             }',
             $notification->body, $notification->title, $notification->titleLink, $notification->body,
             $_SERVER['SLACK_USERNAME'] ?? 'Flux',
-            $_SERVER['SLACK_ICON'] ?? ':cloud:'
+            $_SERVER['SLACK_ICON'] ?? ':cloud:',
+            (!empty($notification->channel)) ? sprintf(', "channel": "%s"', $notification->channel) : null
         );
 
         $options = [


### PR DESCRIPTION
Adds support for namespace mapping.
This allows the user to control where notifications should be sent.

If undefined, the handler will continue to work as it did now.
If defined, separate channels can be given with a namespace scope, so changes in a specific namespace are sent to the desired channel(s).