### PR TITLE
Allow Request to be handled for multiple Notifiers

### DIFF
--- a/server.php
+++ b/server.php
@@ -15,8 +15,17 @@ Amp\Loop::run(function () {
     $server = new Server($sockets, new CallableRequestHandler(
         function(Request $request) {
             $debug = (isset($_SERVER['DEBUG']) && $_SERVER['DEBUG'] == 1);
-            $notifier = ($debug) ? new StdoutNotifier() : new SlackNotifier();
-            $requestHandler = new RequestHandler($notifier);
+            $notifiers = [];
+
+            if ($debug) {
+                $notifiers[] = new StdoutNotifier();
+            }
+
+            if (isset($_SERVER['SLACK_WEBHOOK_URL'])) {
+                $notifiers[] = new SlackNotifier();
+            }
+
+            $requestHandler = new RequestHandler($notifiers);
             return $requestHandler->handle($request);
         }
     ), new IoLogger());

--- a/src/FluxEvent/PayloadProcessor.php
+++ b/src/FluxEvent/PayloadProcessor.php
@@ -10,6 +10,10 @@ class PayloadProcessor
      */
     public function process(string $json): ProcessedPayload
     {
+        if (empty($json)) {
+            throw new \RuntimeException('Cannot process an empty payload.');
+        }
+
         $payload = json_decode($json);
 
         $processedPayload = new ProcessedPayload();

--- a/tests/FluxEvent/PayloadProcessorTest.php
+++ b/tests/FluxEvent/PayloadProcessorTest.php
@@ -36,4 +36,11 @@ class PayloadProcessorTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $processor->process(str_replace('"Type": "commit"', '"Type": "foo"', $json));
     }
+
+    public function testEmptyPayload()
+    {
+        $processor = new PayloadProcessor();
+        $this->expectException(\RuntimeException::class);
+        $processor->process('');
+    }
 }

--- a/tests/FluxEvent/RequestHandlerTest.php
+++ b/tests/FluxEvent/RequestHandlerTest.php
@@ -10,9 +10,15 @@ use TreeHouse\Notifier\StdoutNotifier;
 
 class RequestHandlerTest extends TestCase
 {
+    public function setUp(): void
+    {
+        // Set dummy env vars
+        $_SERVER['DEBUG'] = 0;
+        $_SERVER['SLACK_WEBHOOK_URL'] = 'http://localhost:80';
+    }
+
     public function testValidNotifiers()
     {
-        $_SERVER['SLACK_WEBHOOK_URL'] = 'http://localhost';
         $requestHandler = new RequestHandler([new StdoutNotifier(), new SlackNotifier()]);
 
         $this->assertInstanceOf(RequestHandler::class, $requestHandler);

--- a/tests/FluxEvent/RequestHandlerTest.php
+++ b/tests/FluxEvent/RequestHandlerTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\FluxEvent;
+
+use PHPUnit\Framework\TestCase;
+use TreeHouse\FluxEvent\RequestHandler;
+use TreeHouse\Notifier\SlackNotifier;
+use TreeHouse\Notifier\StdoutNotifier;
+
+class RequestHandlerTest extends TestCase
+{
+    public function testValidNotifiers()
+    {
+        $_SERVER['SLACK_WEBHOOK_URL'] = 'http://localhost';
+        $requestHandler = new RequestHandler([new StdoutNotifier(), new SlackNotifier()]);
+
+        $this->assertInstanceOf(RequestHandler::class, $requestHandler);
+    }
+
+    public function testInvalidNotifiers()
+    {
+        $this->expectExceptionMessage('Only Notifier instances may be passed to RequestHandler');
+        new RequestHandler([new StdoutNotifier(), 'SlackNotifier']);
+
+        $this->expectExceptionMessage('No Notifiers passed to RequestHandler');
+        new RequestHandler([]);
+    }
+}


### PR DESCRIPTION
Allow multiple Notifier instances to be passed to the RequestHandler.
This allows for better flow control of Notifications.