### PR TITLE
Temporarily add Makefile to allow manual test/deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+# Temporary Makefile while GitHub Actions is being fixed for public repos
+# See https://github.community/t5/GitHub-Actions/GitHub-Actions-workflows-can-t-be-executed-on-this-repository/m-p/38153#M3236
+test:
+	docker-compose run --rm composer run-script test
+
+build:
+	docker build .
+
+# Can only deploy with valid Docker login present on dev machine (repo admins only)
+deploy:
+	docker build -t treehouselabs/flux-event-handler:$(git rev-parse --short=8 HEAD) -t treehouselabs/flux-event-handler:latest .
+	docker push treehouselabs/flux-event-handler


### PR DESCRIPTION
Since it looks like GitHub Actions has been (accidentally?) disabled for public repositories in organizations, temporarily add a Makefile that allows devs to run `make test` and `make build` to test / build the app and a `make deploy` target for Docker repository admins to manually deploy new versions of the container image.